### PR TITLE
Add user settings for language and currency

### DIFF
--- a/src/contexts/CurrencyContext.tsx
+++ b/src/contexts/CurrencyContext.tsx
@@ -1,0 +1,79 @@
+import { createContext, useContext, useState, ReactNode, useEffect } from 'react';
+import { supabase } from '../lib/supabase';
+
+export const availableCurrencies = [
+  'USD',
+  'EUR',
+  'GBP',
+  'CAD',
+  'AUD',
+  'JPY'
+];
+
+type CurrencyContextType = {
+  currency: string;
+  setCurrency: (code: string) => void;
+};
+
+const CurrencyContext = createContext<CurrencyContextType | undefined>(undefined);
+
+export const CurrencyProvider = ({ children }: { children: ReactNode }) => {
+  const [currency, setCurrencyState] = useState('USD');
+
+  useEffect(() => {
+    const fetchSettings = async () => {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session?.user) return;
+      const { data } = await supabase
+        .from('user_settings')
+        .select('currency')
+        .eq('user_id', session.user.id)
+        .single();
+      if (data?.currency) {
+        setCurrencyState(data.currency);
+      }
+    };
+
+    fetchSettings();
+
+    const { data: { subscription } } = supabase.auth.onAuthStateChange(async (_ev, session) => {
+      if (session?.user) {
+        const { data } = await supabase
+          .from('user_settings')
+          .select('currency')
+          .eq('user_id', session.user.id)
+          .single();
+        if (data?.currency) {
+          setCurrencyState(data.currency);
+        }
+      }
+    });
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  const setCurrency = async (code: string) => {
+    setCurrencyState(code);
+    const { data: { session } } = await supabase.auth.getSession();
+    if (session?.user) {
+      await supabase
+        .from('user_settings')
+        .upsert({ user_id: session.user.id, currency: code }, { onConflict: 'user_id' });
+    }
+  };
+
+  return (
+    <CurrencyContext.Provider value={{ currency, setCurrency }}>
+      {children}
+    </CurrencyContext.Provider>
+  );
+};
+
+export const useCurrency = () => {
+  const context = useContext(CurrencyContext);
+  if (!context) {
+    throw new Error('useCurrency must be used within a CurrencyProvider');
+  }
+  return context;
+};

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
+import { availableLanguages, useLanguage } from '../contexts/LanguageContext';
+import { availableCurrencies, useCurrency } from '../contexts/CurrencyContext';
 
 const Settings = () => {
+  const { currentLanguage, setLanguage } = useLanguage();
+  const { currency, setCurrency } = useCurrency();
+
   return (
     <div className="p-6 max-w-3xl mx-auto">
       <h1 className="text-2xl font-bold mb-4">Settings</h1>
@@ -31,12 +36,39 @@ const Settings = () => {
 
         <Card>
           <CardHeader>
-            <CardTitle>Account</CardTitle>
+            <CardTitle>User Preferences</CardTitle>
           </CardHeader>
           <CardContent>
-            <p className="text-muted-foreground">
-              Update your account information and preferences.
-            </p>
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium mb-1">Language</label>
+                <select
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md"
+                  value={currentLanguage.code}
+                  onChange={e => setLanguage(e.target.value)}
+                >
+                  {availableLanguages.map(lang => (
+                    <option key={lang.code} value={lang.code}>
+                      {lang.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-1">Currency</label>
+                <select
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md"
+                  value={currency}
+                  onChange={e => setCurrency(e.target.value)}
+                >
+                  {availableCurrencies.map(cur => (
+                    <option key={cur} value={cur}>
+                      {cur}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
           </CardContent>
         </Card>
       </div>

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -6,6 +6,7 @@ import { Toaster } from 'sonner';
 import { ShopProvider } from './contexts/ShopContext';
 import { UserProvider } from './contexts/UserContext';
 import { LanguageProvider } from './contexts/LanguageContext';
+import { CurrencyProvider } from './contexts/CurrencyContext';
 import { RoleProvider } from './context/RoleContext';
 
 // Layouts
@@ -85,9 +86,10 @@ const AppRoutes = () => {
   return (
     <HashRouter>
       <LanguageProvider>
-        <UserProvider>
-          <RoleProvider>
-            <ShopProvider>
+        <CurrencyProvider>
+          <UserProvider>
+            <RoleProvider>
+              <ShopProvider>
               <SubscriptionBanner />
               <Routes>
                 {/* Public pages */}
@@ -180,6 +182,7 @@ const AppRoutes = () => {
             </ShopProvider>
           </RoleProvider>
         </UserProvider>
+        </CurrencyProvider>
       </LanguageProvider>
     </HashRouter>
   );

--- a/supabase/migrations/20250606000000_user_settings.sql
+++ b/supabase/migrations/20250606000000_user_settings.sql
@@ -1,0 +1,34 @@
+/*
+  # Create user_settings table
+
+  1. New Tables
+    - `user_settings` - Stores user specific preferences
+      - `id` (uuid, primary key)
+      - `user_id` (uuid, references auth.users)
+      - `language` (text, default 'en')
+      - `currency` (text, default 'USD')
+      - `created_at` (timestamp)
+      - `updated_at` (timestamp)
+
+  2. Security
+    - Enable RLS on user_settings table
+    - Add policy for authenticated users to manage their own settings
+*/
+
+CREATE TABLE IF NOT EXISTS user_settings (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+  language text NOT NULL DEFAULT 'en',
+  currency text NOT NULL DEFAULT 'USD',
+  created_at timestamptz DEFAULT now() NOT NULL,
+  updated_at timestamptz DEFAULT now() NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_user_settings_user_id ON user_settings(user_id);
+
+ALTER TABLE user_settings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can manage their own settings" ON user_settings
+  FOR ALL
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());


### PR DESCRIPTION
## Summary
- create `user_settings` table migration
- load user preferences in `LanguageContext`
- add new `CurrencyContext`
- provide a form on Settings page to change language and currency
- wrap app with `CurrencyProvider`

## Testing
- `npm run lint` *(fails: Invalid option '--ext' when using eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_684496986a4083288b55889eb7abad30