### PR TITLE
Share single OpenAI instance

### DIFF
--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -1,6 +1,6 @@
 import { OpenAI } from 'openai';
 
-const openai = new OpenAI({
+export const openai = new OpenAI({
   apiKey: import.meta.env.VITE_OPENAI_API_KEY,
   dangerouslyAllowBrowser: true
 });

--- a/src/lib/seoAI.ts
+++ b/src/lib/seoAI.ts
@@ -1,9 +1,4 @@
-import { OpenAI } from 'openai';
-
-const openai = new OpenAI({
-  apiKey: import.meta.env.VITE_OPENAI_API_KEY,
-  dangerouslyAllowBrowser: true
-});
+import { openai } from './openai';
 
 export async function auditSEOWithAI({
   title,

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -1,9 +1,4 @@
-import OpenAI from 'openai';
-
-const openai = new OpenAI({
-  apiKey: import.meta.env.VITE_OPENAI_API_KEY,
-  dangerouslyAllowBrowser: true
-});
+import { openai } from '@/lib/openai';
 
 export const aiService = {
   async generateProductDescription(product: {


### PR DESCRIPTION
## Summary
- export the shared `openai` instance from `src/lib/openai.ts`
- reuse this instance inside `seoAI.ts` and `aiService.ts`

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6849aece93248328b6f6dc62fb0ec5aa