### PR TITLE
Move supabase import to top

### DIFF
--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -1,4 +1,5 @@
 import { loadStripe } from '@stripe/stripe-js';
+import { supabase } from './supabase';
 
 // Make sure to call `loadStripe` outside of a component's render to avoid
 // recreating the `Stripe` object on every render.
@@ -71,5 +72,3 @@ export const getCustomerPortalLink = async (customerId: string) => {
     throw error;
   }
 };
-
-import { supabase } from './supabase';


### PR DESCRIPTION
## Summary
- move `supabase` import to the top of `stripe.ts`

## Testing
- `npm run build`
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_6849aec5ef288328805f4a73ef853e92