### PR TITLE
Fix Supabase env check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,8 @@
 # OpenAI
 VITE_OPENAI_API_KEY=your_openai_key_here
 
-# Supabase
+# Supabase (variables requises)
+# VITE_SUPABASE_URL et VITE_SUPABASE_ANON_KEY doivent être définies
 VITE_SUPABASE_URL=https://yourproject.supabase.co
 VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
 

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,8 +1,13 @@
 import { createClient } from '@supabase/supabase-js';
 
-// Utilisation de valeurs par défaut pour le développement local
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL || 'https://lyxpzzskjflqdzzkffyz.supabase.co';
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imx5eHB6enNramZscWR6emtmZnl6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDYyNzY2MzEsImV4cCI6MjA2MTg1MjYzMX0.pRVL8_yDwok4RB9vL1PpR6KxgWaJnMJtlodXTvYTB7g';
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error(
+    'Missing Supabase configuration. Please define VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY.'
+  );
+}
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
   auth: {


### PR DESCRIPTION
## Summary
- remove fallback Supabase credentials
- throw when Supabase env vars are missing
- document that Supabase vars are required in `.env.example`

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_6849aec24c7c832883033b340f449413