### PR TITLE
Expose FastAPI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,10 @@
 ```bash
 git tag v6.8-final
 git push origin v6.8-final
+
+### 📚 Documentation API
+
+L'application FastAPI expose une interface Swagger disponible sur `/docs`.
+Vous pouvez également récupérer le schéma brut via `/openapi.json`.
+En local, lancez `uvicorn backend.main:app` puis ouvrez
+<http://localhost:8000/docs> pour explorer les différentes routes.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,22 @@
 from fastapi import FastAPI
+from fastapi.openapi.utils import get_openapi
 from backend.api import router
 
-app = FastAPI()
+app = FastAPI(docs_url="/docs", openapi_url="/openapi.json")
 app.include_router(router)
+
+
+def custom_openapi():
+    if app.openapi_schema:
+        return app.openapi_schema
+    openapi_schema = get_openapi(
+        title="Shopopti API",
+        version="1.0.0",
+        description="Shopopti backend API documentation.",
+        routes=app.routes,
+    )
+    app.openapi_schema = openapi_schema
+    return app.openapi_schema
+
+
+app.openapi = custom_openapi


### PR DESCRIPTION
## Summary
- configure FastAPI to serve `/docs` and `/openapi.json`
- document how to access the API docs

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `python -m py_compile backend/main.py backend/api/__init__.py backend/api/connect.py backend/api/stripe_checkout.py backend/api/stripe_webhook.py`

------
https://chatgpt.com/codex/tasks/task_e_6849a2e5ca5c8328a446a95067f0865f