### PR TITLE
Add import extension API

### DIFF
--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -2,8 +2,10 @@ from fastapi import APIRouter
 from .stripe_checkout import router as stripe_checkout_router
 from .stripe_webhook import router as stripe_webhook_router
 from .connect import router as connect_router
+from .import_extension import router as import_extension_router
 
 router = APIRouter()
 router.include_router(stripe_checkout_router)
 router.include_router(stripe_webhook_router)
 router.include_router(connect_router)
+router.include_router(import_extension_router)

--- a/backend/api/import_extension.py
+++ b/backend/api/import_extension.py
@@ -1,0 +1,49 @@
+from fastapi import APIRouter
+from pydantic import BaseModel, Field
+from typing import List, Optional
+from supabase import create_client
+import os
+
+router = APIRouter()
+
+supabase_url = os.getenv("SUPABASE_URL") or ""
+supabase_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or ""
+supabase = create_client(supabase_url, supabase_key)
+
+
+class Product(BaseModel):
+    title: str = Field(..., description="Product title")
+    description: Optional[str] = Field(None, description="Product description")
+    price: float = Field(..., description="Product price")
+    user_id: Optional[str] = Field(None, description="Owner user id")
+
+
+class ImportRequest(BaseModel):
+    products: List[Product]
+
+
+class ImportResponse(BaseModel):
+    inserted: int
+    failed: int
+
+
+@router.post("/api/import/products", response_model=ImportResponse)
+async def import_products(payload: ImportRequest):
+    inserted = 0
+    for product in payload.products:
+        result = (
+            supabase.table("products")
+            .insert(
+                {
+                    "user_id": product.user_id,
+                    "title": product.title,
+                    "description": product.description,
+                    "price": product.price,
+                }
+            )
+            .execute()
+        )
+        if getattr(result, "error", None) is None:
+            inserted += 1
+    failed = len(payload.products) - inserted
+    return ImportResponse(inserted=inserted, failed=failed)


### PR DESCRIPTION
## Summary
- add `/api/import/products` endpoint to store product payloads
- register the new router

## Testing
- `npm run lint` *(fails: Unknown env config `http-proxy`, Invalid option `--ext`)*

------
https://chatgpt.com/codex/tasks/task_e_6849a2b7d560832895ed575a3b81ded1