### PR TITLE
Add Chrome extension scripts

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,14 @@
+const API_URL = 'https://app.shopopti.com/api/import-extension';
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === 'SCRAPED_PRODUCT') {
+    fetch(API_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(message.data)
+    })
+      .then(res => res.json())
+      .then(res => console.log('Import response', res))
+      .catch(err => console.error('Import error', err));
+  }
+});

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,0 +1,19 @@
+function scrapeProduct() {
+  const title = document.querySelector('meta[property="og:title"]')?.content || document.title;
+  const priceEl = document.querySelector('[itemprop="price"],[data-price],.price');
+  const price = priceEl?.getAttribute('content') || priceEl?.dataset.price || priceEl?.textContent || '';
+  const image = document.querySelector('meta[property="og:image"]')?.content || document.querySelector('img')?.src || '';
+  return {
+    title: title.trim(),
+    price: price.trim(),
+    image,
+    url: window.location.href
+  };
+}
+
+try {
+  const data = scrapeProduct();
+  chrome.runtime.sendMessage({ type: 'SCRAPED_PRODUCT', data });
+} catch (e) {
+  console.error('Scrape error', e);
+}

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -10,7 +10,8 @@
   "host_permissions": [
     "https://*.aliexpress.com/*",
     "https://*.amazon.com/*",
-    "https://*.myshopify.com/*"
+    "https://*.myshopify.com/*",
+    "https://app.shopopti.com/*"
   ],
   "action": {
     "default_popup": "popup.html",

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -6,41 +6,8 @@
   <title>Shopopti+ Product Importer</title>
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2/dist/tailwind.min.css" rel="stylesheet">
 </head>
-<body class="w-80 p-4 bg-gray-50">
-  <div class="flex items-center justify-between mb-4">
-    <h1 class="text-lg font-semibold">Shopopti+</h1>
-    <div id="status" class="text-sm"></div>
-  </div>
-
-  <div id="login-form" class="hidden">
-    <input type="text" id="shop-url" placeholder="your-store.myshopify.com" class="w-full mb-2 p-2 border rounded">
-    <input type="password" id="access-token" placeholder="Access Token" class="w-full mb-2 p-2 border rounded">
-    <button id="login" class="w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700">Connect Store</button>
-  </div>
-
-  <div id="import-panel" class="hidden">
-    <div id="product-preview" class="mb-4">
-      <img id="product-image" class="w-full h-40 object-cover rounded mb-2">
-      <h2 id="product-title" class="text-sm font-medium mb-1"></h2>
-      <p id="product-price" class="text-sm text-gray-600"></p>
-    </div>
-
-    <button id="import" class="w-full bg-green-600 text-white py-2 rounded hover:bg-green-700 mb-2">
-      Import to Shopify
-    </button>
-
-    <div id="settings" class="text-sm">
-      <label class="flex items-center mb-2">
-        <input type="checkbox" id="optimize-title" checked class="mr-2">
-        Optimize title with AI
-      </label>
-      <label class="flex items-center">
-        <input type="checkbox" id="optimize-description" checked class="mr-2">
-        Generate optimized description
-      </label>
-    </div>
-  </div>
-
+<body>
+  <div id="root"></div>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+function Popup() {
+    return (React.createElement("div", { className: "w-80 p-4 bg-gray-50" },
+        React.createElement("div", { className: "flex items-center justify-between mb-4" },
+            React.createElement("h1", { className: "text-lg font-semibold" }, "Shopopti+"),
+            React.createElement("div", { id: "status", className: "text-sm" })),
+        React.createElement("div", { id: "login-form", className: "hidden" },
+            React.createElement("input", { type: "text", id: "shop-url", placeholder: "your-store.myshopify.com", className: "w-full mb-2 p-2 border rounded" }),
+            React.createElement("input", { type: "password", id: "access-token", placeholder: "Access Token", className: "w-full mb-2 p-2 border rounded" }),
+            React.createElement("button", { id: "login", className: "w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700" }, "Connect Store")),
+        React.createElement("div", { id: "import-panel", className: "hidden" },
+            React.createElement("div", { id: "product-preview", className: "mb-4" },
+                React.createElement("img", { id: "product-image", className: "w-full h-40 object-cover rounded mb-2" }),
+                React.createElement("h2", { id: "product-title", className: "text-sm font-medium mb-1" }),
+                React.createElement("p", { id: "product-price", className: "text-sm text-gray-600" })),
+            React.createElement("button", { id: "import", className: "w-full bg-green-600 text-white py-2 rounded hover:bg-green-700 mb-2" }, "Import to Shopify"),
+            React.createElement("div", { id: "settings", className: "text-sm" },
+                React.createElement("label", { className: "flex items-center mb-2" },
+                    React.createElement("input", { type: "checkbox", id: "optimize-title", defaultChecked: true, className: "mr-2" }),
+                    "Optimize title with AI"),
+                React.createElement("label", { className: "flex items-center" },
+                    React.createElement("input", { type: "checkbox", id: "optimize-description", defaultChecked: true, className: "mr-2" }),
+                    "Generate optimized description")))));
+}
+const rootEl = document.getElementById('root');
+if (rootEl) {
+    createRoot(rootEl).render(React.createElement(Popup, null));
+}

--- a/extension/popup.tsx
+++ b/extension/popup.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+
+function Popup() {
+  return (
+    <div className="w-80 p-4 bg-gray-50">
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-lg font-semibold">Shopopti+</h1>
+        <div id="status" className="text-sm" />
+      </div>
+
+      <div id="login-form" className="hidden">
+        <input type="text" id="shop-url" placeholder="your-store.myshopify.com" className="w-full mb-2 p-2 border rounded" />
+        <input type="password" id="access-token" placeholder="Access Token" className="w-full mb-2 p-2 border rounded" />
+        <button id="login" className="w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700">Connect Store</button>
+      </div>
+
+      <div id="import-panel" className="hidden">
+        <div id="product-preview" className="mb-4">
+          <img id="product-image" className="w-full h-40 object-cover rounded mb-2" />
+          <h2 id="product-title" className="text-sm font-medium mb-1" />
+          <p id="product-price" className="text-sm text-gray-600" />
+        </div>
+
+        <button id="import" className="w-full bg-green-600 text-white py-2 rounded hover:bg-green-700 mb-2">Import to Shopify</button>
+
+        <div id="settings" className="text-sm">
+          <label className="flex items-center mb-2">
+            <input type="checkbox" id="optimize-title" defaultChecked className="mr-2" />
+            Optimize title with AI
+          </label>
+          <label className="flex items-center">
+            <input type="checkbox" id="optimize-description" defaultChecked className="mr-2" />
+            Generate optimized description
+          </label>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const rootEl = document.getElementById('root');
+if (rootEl) {
+  createRoot(rootEl).render(<Popup />);
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc && vite build && npm run build-extension",
+    "build-extension": "tsc extension/popup.tsx --jsx react --target ES2017 --module ESNext --outDir extension --skipLibCheck --allowSyntheticDefaultImports",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "i18n": "i18next-scanner --config i18next-scanner.config.js"


### PR DESCRIPTION
## Summary
- implement React popup in `popup.tsx` and compile to `popup.js`
- scrape product details with `content.js`
- send scraped data from `background.js` to `/api/import-extension`
- update host permissions in `manifest.json`
- compile extension via new build script and adjust popup HTML

## Testing
- `npm run lint` *(fails: Invalid option '--ext' ...)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6849a2b00fa88328918acdaa4f978d1f