### PR TITLE
Centralize OpenAI logic

### DIFF
--- a/src/hooks/useChatbot.ts
+++ b/src/hooks/useChatbot.ts
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { askChatGPT } from "../lib/openai";
+import { askChatGPT } from "../lib/ai/openai";
 
 export function useChatbot() {
   const [messages, setMessages] = useState<{ role: string; content: string }[]>([]);

--- a/src/lib/ai/openai.ts
+++ b/src/lib/ai/openai.ts
@@ -1,6 +1,6 @@
 import { OpenAI } from 'openai';
 
-const openai = new OpenAI({
+export const openai = new OpenAI({
   apiKey: import.meta.env.VITE_OPENAI_API_KEY,
   dangerouslyAllowBrowser: true
 });

--- a/src/lib/seoAI.ts
+++ b/src/lib/seoAI.ts
@@ -1,9 +1,4 @@
-import { OpenAI } from 'openai';
-
-const openai = new OpenAI({
-  apiKey: import.meta.env.VITE_OPENAI_API_KEY,
-  dangerouslyAllowBrowser: true
-});
+import { openai } from '@/lib/ai/openai';
 
 export async function auditSEOWithAI({
   title,

--- a/src/pages/blog-ai.tsx
+++ b/src/pages/blog-ai.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { askChatGPT } from '@/lib/openai';
+import { askChatGPT } from '@/lib/ai/openai';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';

--- a/src/pages/seo-ai.tsx
+++ b/src/pages/seo-ai.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { askChatGPT } from '@/lib/openai';
+import { askChatGPT } from '@/lib/ai/openai';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';

--- a/src/pages/seo-competitor.tsx
+++ b/src/pages/seo-competitor.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Textarea } from '@/components/ui/textarea';
 import { Loader2 } from 'lucide-react';
-import { askChatGPT } from '@/lib/openai';
+import { askChatGPT } from '@/lib/ai/openai';
 
 export default function SeoCompetitorPage() {
   const [url, setUrl] = useState('');

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -1,9 +1,4 @@
-import OpenAI from 'openai';
-
-const openai = new OpenAI({
-  apiKey: import.meta.env.VITE_OPENAI_API_KEY,
-  dangerouslyAllowBrowser: true
-});
+import { openai } from '@/lib/ai/openai';
 
 export const aiService = {
   async generateProductDescription(product: {


### PR DESCRIPTION
## Summary
- move OpenAI helper to `lib/ai/openai.ts`
- use centralized client in services and pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68498cfb5dd88328a71deb79eca2cb48