### PR TITLE
Remove auto-git operations from fix-vercel

### DIFF
--- a/fix-vercel.sh
+++ b/fix-vercel.sh
@@ -15,10 +15,11 @@ if [ ! -f "package.json" ]; then
   exit 1
 fi
 
-# 3. Ajouter au git et pousser
-git add .
-git commit -m "fix: repositionner les fichiers à la racine pour Vercel"
-git push origin v6.8
-
-echo "✅ Push effectué. Tu peux maintenant redeployer sur Vercel."
+# 3. Instructions Git
+echo "\n✅ Les fichiers sont prêts. Exécutez les commandes suivantes pour enregistrer"
+echo "manuellement les changements :"
+echo "\n   git add ."
+echo "   git commit -m 'fix: repositionner les fichiers à la racine pour Vercel'"
+echo "   git push origin <votre-branche>"
+echo "\nEnsuite, redeployez sur Vercel."
 


### PR DESCRIPTION
## Summary
- stop `fix-vercel.sh` from committing and pushing automatically
- print manual instructions for git commands

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_684989fa89e88328a83a2f2a612f19c8