### PR TITLE
Update supabase env handling

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,8 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
 
-// Utilisation de valeurs par défaut pour le développement local
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL || 'https://lyxpzzskjflqdzzkffyz.supabase.co';
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imx5eHB6enNramZscWR6emtmZnl6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDYyNzY2MzEsImV4cCI6MjA2MTg1MjYzMX0.pRVL8_yDwok4RB9vL1PpR6KxgWaJnMJtlodXTvYTB7g';
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
   auth: {


### PR DESCRIPTION
## Summary
- remove default Supabase URL/anon key values
- rely only on `import.meta.env` variables

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npx eslint src/lib/supabase.ts` *(fails: Cannot find package 'typescript-eslint')*

------
https://chatgpt.com/codex/tasks/task_e_684987a2779c8328ace14ffc053e889d