### PR TITLE
Add CI workflows for lint and build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,16 @@
+name: Build
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,16 @@
+name: Lint
+on:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to lint PRs
- add GitHub Actions workflow to build PRs

## Testing
- `npm run lint` *(fails: "Invalid option '--ext'")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6849862c7e808328a736b798e19dbc5e