### PR TITLE
Remove supabase URL fallbacks

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,8 +1,12 @@
 import { createClient } from '@supabase/supabase-js';
 
-// Utilisation de valeurs par défaut pour le développement local
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL || 'https://lyxpzzskjflqdzzkffyz.supabase.co';
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imx5eHB6enNramZscWR6emtmZnl6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDYyNzY2MzEsImV4cCI6MjA2MTg1MjYzMX0.pRVL8_yDwok4RB9vL1PpR6KxgWaJnMJtlodXTvYTB7g';
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  console.warn('Missing Supabase environment variables');
+  throw new Error('VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY must be defined');
+}
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
   auth: {


### PR DESCRIPTION
## Summary
- rely solely on environment variables for Supabase client
- throw an error when required variables are missing

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_6849861479c0832893a922aca8e713bc